### PR TITLE
ignore. testing in my repo first

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,2 @@
+pytest>=8.0
+pytest-asyncio>=0.23

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,162 @@
+"""Test bootstrap for the Kokoro TTS integration.
+
+The integration modules import ``homeassistant`` (and a few third-party libs) at
+module load time. Home Assistant is a very heavy dependency, so instead of
+installing it we register minimal stub modules in ``sys.modules`` before the
+integration is imported. The pure helper logic under test (persona
+classification/filtering, language-code resolution, unique-id hashing) does not
+touch any real Home Assistant behaviour, so the stubs only need to make the
+imports succeed.
+
+Each stub group is only installed when the real top-level package is NOT
+importable, so adding ``homeassistant``/``aiohttp``/``voluptuous`` to the test
+environment later transparently runs the tests against the real packages
+instead of being silently clobbered by these stubs.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+# Make the repo root importable as `custom_components.kokoro_tts...`.
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def _importable(name: str) -> bool:
+    """True if a real (non-stub) top-level package is installed."""
+    if name in sys.modules:
+        return True
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def _mod(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    sys.modules[name] = module
+    return module
+
+
+def _stub_homeassistant() -> None:
+    ha = _mod("homeassistant")
+
+    config_entries = _mod("homeassistant.config_entries")
+
+    class ConfigFlow:
+        # Absorb `class X(ConfigFlow, domain=...)` keyword.
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__()
+
+    class OptionsFlow:
+        pass
+
+    class ConfigEntry:
+        pass
+
+    config_entries.ConfigFlow = ConfigFlow
+    config_entries.OptionsFlow = OptionsFlow
+    config_entries.ConfigEntry = ConfigEntry
+    ha.config_entries = config_entries
+
+    const = _mod("homeassistant.const")
+
+    class Platform:
+        TTS = "tts"
+
+    const.Platform = Platform
+
+    core = _mod("homeassistant.core")
+
+    class HomeAssistant:
+        pass
+
+    core.HomeAssistant = HomeAssistant
+    core.callback = lambda func: func
+
+    exceptions = _mod("homeassistant.exceptions")
+
+    class ConfigEntryAuthFailed(Exception):
+        pass
+
+    exceptions.ConfigEntryAuthFailed = ConfigEntryAuthFailed
+
+    helpers = _mod("homeassistant.helpers")
+
+    cv = _mod("homeassistant.helpers.config_validation")
+    cv.config_entry_only_config_schema = lambda domain: {}
+    helpers.config_validation = cv
+
+    selector = _mod("homeassistant.helpers.selector")
+    selector.selector = lambda spec: spec
+    helpers.selector = selector
+
+    aiohttp_client = _mod("homeassistant.helpers.aiohttp_client")
+
+    def async_get_clientsession(hass):
+        raise RuntimeError("async_get_clientsession must be patched in tests")
+
+    aiohttp_client.async_get_clientsession = async_get_clientsession
+    helpers.aiohttp_client = aiohttp_client
+
+    components = _mod("homeassistant.components")
+    tts_pkg = _mod("homeassistant.components.tts")
+    tts_entity = _mod("homeassistant.components.tts.entity")
+
+    class TextToSpeechEntity:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    tts_entity.TextToSpeechEntity = TextToSpeechEntity
+    tts_entity.TtsAudioType = tuple
+    tts_pkg.entity = tts_entity
+    components.tts = tts_pkg
+    ha.components = components
+
+
+def _stub_voluptuous() -> None:
+    vol = _mod("voluptuous")
+
+    class _Schema:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _Marker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    vol.Schema = _Schema
+    vol.Required = _Marker
+    vol.Optional = _Marker
+
+
+def _stub_aiohttp() -> None:
+    aiohttp = _mod("aiohttp")
+
+    class ClientTimeout:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class ClientError(Exception):
+        pass
+
+    aiohttp.ClientTimeout = ClientTimeout
+    aiohttp.ClientSession = object
+    aiohttp.ClientError = ClientError
+    aiohttp.ClientSSLError = type("ClientSSLError", (ClientError,), {})
+    aiohttp.ClientConnectorError = type("ClientConnectorError", (ClientError,), {})
+
+
+def _install_stubs() -> None:
+    if not _importable("homeassistant"):
+        _stub_homeassistant()
+    if not _importable("voluptuous"):
+        _stub_voluptuous()
+    if not _importable("aiohttp"):
+        _stub_aiohttp()
+
+
+_install_stubs()

--- a/tests/test_persona_helpers.py
+++ b/tests/test_persona_helpers.py
@@ -1,0 +1,105 @@
+"""Tests for persona classification, filtering and unique-id helpers."""
+from __future__ import annotations
+
+from custom_components.kokoro_tts.config_flow import (
+    _calc_unique_id,
+    derive_persona_info,
+    filter_personas_by_language_and_sex,
+    get_persona_display_name,
+    get_persona_select_options,
+)
+
+
+def test_derive_persona_info_known_prefixes():
+    assert derive_persona_info("af_heart") == ("American English", "Female", "Heart")
+    assert derive_persona_info("bm_george") == ("British English", "Male", "George")
+    assert derive_persona_info("zf_xiaoyi") == ("Mandarin Chinese", "Female", "Xiaoyi")
+    assert derive_persona_info("pm_alex") == ("Brazilian Portuguese", "Male", "Alex")
+
+
+def test_derive_persona_info_multiword_name():
+    assert derive_persona_info("af_new_voice") == (
+        "American English",
+        "Female",
+        "New Voice",
+    )
+
+
+def test_derive_persona_info_invalid():
+    assert derive_persona_info("qf_foo") is None  # unknown language letter
+    assert derive_persona_info("ax_foo") is None  # unknown sex letter
+    assert derive_persona_info("a") is None  # too short
+    assert derive_persona_info("") is None
+    assert derive_persona_info("af") is None  # no name component (no underscore)
+    assert derive_persona_info("af_") is None  # empty name component
+
+
+def test_filter_all_includes_unmapped():
+    personas = ["af_heart", "af_unknownvoice", "zz_weird"]
+    out = filter_personas_by_language_and_sex(personas, "All Languages", "All")
+    assert set(out) == {"af_heart", "af_unknownvoice", "zz_weird"}
+
+
+def test_filter_unmapped_voice_visible_under_language_filter():
+    # Regression: a server voice that is NOT in PERSONA_MAPPINGS must still show
+    # when a language/sex filter is active. Previously it was hidden unless both
+    # filters were "All".
+    personas = ["af_heart", "af_brandnew", "bm_george"]
+    out = filter_personas_by_language_and_sex(personas, "American English", "Female")
+    assert "af_brandnew" in out
+    assert "af_heart" in out
+    assert "bm_george" not in out
+
+
+def test_filter_excludes_other_language_and_sex():
+    personas = ["af_heart", "am_adam", "bm_george"]
+    out = filter_personas_by_language_and_sex(personas, "American English", "Male")
+    assert out == ["am_adam"]
+
+
+def test_filter_unclassifiable_hidden_when_filtered():
+    personas = ["af_heart", "zz_weird"]
+    out = filter_personas_by_language_and_sex(personas, "American English", "All")
+    assert out == ["af_heart"]
+
+
+def test_persona_display_name_mapped_and_unmapped():
+    assert get_persona_display_name("af_heart", "American English", "Female") == "Heart"
+    # Unmapped codes fall back to the raw code.
+    assert get_persona_display_name("af_brandnew") == "af_brandnew"
+
+
+def test_select_options_use_code_as_value():
+    options = get_persona_select_options(["af_heart", "am_adam"], "All Languages", "All")
+    by_label = {o["label"]: o["value"] for o in options}
+    assert by_label["Heart (American English, Female)"] == "af_heart"
+    assert by_label["Adam (American English, Male)"] == "am_adam"
+
+
+def test_select_options_resolve_shared_display_names():
+    # jf_alpha and hf_alpha both display as "Alpha" but must keep distinct values.
+    options = get_persona_select_options(["jf_alpha", "hf_alpha"], "All Languages", "All")
+    labels = {o["value"]: o["label"] for o in options}
+    assert set(labels) == {"jf_alpha", "hf_alpha"}
+    assert labels["jf_alpha"] == "Alpha (Japanese, Female)"
+    assert labels["hf_alpha"] == "Alpha (Hindi, Female)"
+
+
+def test_select_options_filtered_by_language_includes_unmapped():
+    options = get_persona_select_options(
+        ["af_heart", "jf_alpha", "af_brandnew"], "American English", "All"
+    )
+    assert {o["value"] for o in options} == {"af_heart", "af_brandnew"}
+
+
+def test_select_options_empty_uses_blank_value_placeholder():
+    options = get_persona_select_options(["jf_alpha"], "American English", "Female")
+    assert len(options) == 1
+    assert options[0]["value"] == ""
+
+
+def test_calc_unique_id_stable_and_distinct():
+    first = _calc_unique_id("http://host:8880")
+    assert first == _calc_unique_id("http://host:8880")
+    assert len(first) == 12
+    assert first != _calc_unique_id("http://other:8880")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,48 @@
+"""Tests for config-entry setup wiring (the options-reload listener)."""
+from __future__ import annotations
+
+from custom_components.kokoro_tts import async_reload_entry, async_setup_entry
+
+
+class _FakeConfigEntries:
+    def __init__(self):
+        self.forwarded = None
+
+    async def async_forward_entry_setups(self, entry, platforms):
+        self.forwarded = list(platforms)
+
+
+class _FakeHass:
+    def __init__(self):
+        self.config_entries = _FakeConfigEntries()
+
+
+class _FakeEntry:
+    entry_id = "entry-1"
+
+    def __init__(self):
+        self.listener = None
+        self.unload_callbacks = []
+
+    def add_update_listener(self, callback):
+        self.listener = callback
+        return "remove-handle"
+
+    def async_on_unload(self, handle):
+        self.unload_callbacks.append(handle)
+
+
+async def test_setup_entry_registers_options_reload_listener():
+    hass = _FakeHass()
+    entry = _FakeEntry()
+
+    result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    # The options-update listener must be wired to async_reload_entry so that
+    # changing options rebuilds the TTS entity without a restart...
+    assert entry.listener is async_reload_entry
+    # ...and its removal must be registered for cleanup on unload.
+    assert "remove-handle" in entry.unload_callbacks
+    # The TTS platform is forwarded (Platform.TTS == "tts").
+    assert hass.config_entries.forwarded == ["tts"]

--- a/tests/test_tts_entity.py
+++ b/tests/test_tts_entity.py
@@ -1,0 +1,68 @@
+"""Tests for the TTS entity's pure helpers (lang-code, error map, unique-id)."""
+from __future__ import annotations
+
+from custom_components.kokoro_tts.tts import KokoroTTSEntity
+
+
+def _entity(**overrides):
+    kwargs = dict(
+        unique_id="entry-abc",
+        name="kokoro",
+        base_url="http://host:8880",
+        api_key="not-needed",
+        model="kokoro",
+        persona="af_heart",
+        speed=1.0,
+        fmt="mp3",
+        language=None,
+    )
+    kwargs.update(overrides)
+    return KokoroTTSEntity(**kwargs)
+
+
+def test_supported_language_follows_persona():
+    # An English persona advertises "en"; a Japanese persona advertises "ja".
+    assert _entity(persona="af_heart")._attr_supported_languages == ["en"]
+    entity = _entity(persona="jf_alpha")
+    assert entity._attr_supported_languages == ["ja"]
+    assert entity._attr_default_language == "ja"
+
+
+def test_supported_language_uses_configured_accent_override():
+    # The configured Voice Accent wins over the persona prefix.
+    entity = _entity(persona="af_heart", language="Mandarin Chinese")
+    assert entity._attr_supported_languages == ["zh"]
+    assert entity._attr_default_language == "zh"
+
+
+def test_unique_id_comes_from_entry_id():
+    # Two entities from different entries must not collide.
+    assert _entity(unique_id="entry-1")._attr_unique_id == "entry-1"
+    assert _entity(unique_id="entry-2")._attr_unique_id == "entry-2"
+
+
+def test_lang_code_prefers_configured_language():
+    entity = _entity(language="British English")
+    # Configured language wins over the persona prefix ("af_" -> "a").
+    assert entity._get_lang_code("af_heart") == "b"
+
+
+def test_lang_code_falls_back_to_persona_prefix():
+    entity = _entity(language=None)
+    assert entity._get_lang_code("jf_alpha") == "j"
+
+
+def test_lang_code_none_when_unknown():
+    entity = _entity(language=None)
+    assert entity._get_lang_code(None) is None
+
+
+def test_lang_code_ignores_all_languages_default():
+    # "All Languages" is not a real lang_code; should fall back to the prefix.
+    entity = _entity(language="All Languages")
+    assert entity._get_lang_code("zm_yunxi") == "z"
+
+
+def test_handle_http_error_known_and_unknown():
+    assert "Authentication failed" in KokoroTTSEntity._handle_http_error(401, "")
+    assert KokoroTTSEntity._handle_http_error(418, "teapot").startswith("HTTP 418")

--- a/tests/test_tts_request.py
+++ b/tests/test_tts_request.py
@@ -1,0 +1,98 @@
+"""Async tests for the TTS request flow (shared session, 401 -> reauth)."""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.kokoro_tts import tts
+from custom_components.kokoro_tts.tts import KokoroTTSEntity
+
+# Resolves to the real package or the conftest stub, whichever is installed;
+# tts.py raises the same class, so isinstance/pytest.raises matches either way.
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+
+class _FakeResponse:
+    def __init__(self, status=200, body=b"AUDIO", content_type="audio/mpeg",
+                 json_data=None, text="error-body"):
+        self.status = status
+        self._body = body
+        self.headers = {"content-type": content_type}
+        self._json = json_data
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def text(self):
+        return self._text
+
+    async def read(self):
+        return self._body
+
+    async def json(self):
+        return self._json
+
+
+class _FakeSession:
+    """Mimics the subset of aiohttp.ClientSession the entity uses."""
+
+    def __init__(self, response):
+        self._response = response
+
+    def post(self, *args, **kwargs):
+        return self._response
+
+    def get(self, *args, **kwargs):
+        return self._response
+
+
+def _entity():
+    entity = KokoroTTSEntity(
+        unique_id="entry-abc",
+        name="kokoro",
+        base_url="http://host:8880",
+        api_key="secret",
+        model="kokoro",
+        persona="af_heart",
+        speed=1.0,
+        fmt="mp3",
+        language=None,
+    )
+    # self.hass is only handed to the (patched) async_get_clientsession.
+    entity.hass = object()
+    return entity
+
+
+async def test_get_tts_audio_happy_path(monkeypatch):
+    session = _FakeSession(_FakeResponse(status=200, body=b"AUDIO"))
+    monkeypatch.setattr(tts, "async_get_clientsession", lambda hass: session)
+
+    fmt, audio = await _entity().async_get_tts_audio("hello", "en")
+
+    assert fmt == "mp3"
+    assert audio == b"AUDIO"
+
+
+async def test_get_tts_audio_401_raises_auth_failed(monkeypatch):
+    session = _FakeSession(_FakeResponse(status=401, text="nope"))
+    monkeypatch.setattr(tts, "async_get_clientsession", lambda hass: session)
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await _entity().async_get_tts_audio("hello", "en")
+
+
+async def test_get_tts_audio_server_error_raises_runtime_error(monkeypatch):
+    session = _FakeSession(_FakeResponse(status=500, text="boom"))
+    monkeypatch.setattr(tts, "async_get_clientsession", lambda hass: session)
+
+    with pytest.raises(RuntimeError):
+        await _entity().async_get_tts_audio("hello", "en")
+
+
+async def test_get_tts_audio_empty_message_rejected():
+    # Validated before any network call, so no session patching needed.
+    with pytest.raises(ValueError):
+        await _entity().async_get_tts_audio("   ", "en")


### PR DESCRIPTION
- Unit tests for the persona helpers (classification/filtering, code-as-value selector options, shared display-name resolution), the TTS entity (lang-code resolution, language advertising, HTTP error mapping), the async request flow (happy path, 401 -> ConfigEntryAuthFailed, 500, empty message) and the options-reload listener.
- conftest stubs Home Assistant only when it isn't installed, so the suite runs without HA and won't clobber real packages if they are present.
- Tests workflow runs pytest on Python 3.12 and 3.13 via requirements_test.txt.

Note: these tests import the fixes from the integration-fixes branch, so CI here is green only once that branch is merged.