### PR TITLE
fix: advertise every language Kokoro supports

### DIFF
--- a/custom_components/kokoro_tts/const.py
+++ b/custom_components/kokoro_tts/const.py
@@ -137,6 +137,27 @@ LANGUAGE_CODE_MAP: dict[str, str] = {
     "Brazilian Portuguese": "p",
 }
 
+# Maps our language display names to the language codes Home Assistant uses.
+# Home Assistant hides a TTS entity from any pipeline whose language is not
+# advertised here, so this must cover every language Kokoro can speak.
+LANGUAGE_HA_CODE_MAP: dict[str, str] = {
+    "American English": "en",
+    "British English": "en-GB",
+    "Japanese": "ja",
+    "Mandarin Chinese": "zh",
+    "Spanish": "es",
+    "French": "fr",
+    "Hindi": "hi",
+    "Italian": "it",
+    "Brazilian Portuguese": "pt-BR",
+}
+
+# Advertised to Home Assistant, derived from the voices Kokoro ships with.
+SUPPORTED_LANGUAGES: list[str] = sorted(set(LANGUAGE_HA_CODE_MAP.values()))
+
+# Used when no language is configured, or when "All Languages" is selected.
+DEFAULT_HA_LANGUAGE = "en"
+
 # Consolidated defaults dictionary
 DEFAULTS: dict[str, Any] = {
     CONF_API_KEY: DEFAULT_API_KEY,

--- a/custom_components/kokoro_tts/tts.py
+++ b/custom_components/kokoro_tts/tts.py
@@ -22,12 +22,15 @@ from .const import (
     CONF_SPEED,
     DEFAULT_API_KEY,
     DEFAULT_FORMAT,
+    DEFAULT_HA_LANGUAGE,
     DEFAULT_MODEL,
     DEFAULT_SAMPLE_RATE,
     DEFAULT_SPEED,
     DEFAULT_VOLUME_MULTIPLIER,
     DOMAIN,
     LANGUAGE_CODE_MAP,
+    LANGUAGE_HA_CODE_MAP,
+    SUPPORTED_LANGUAGES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -101,9 +104,13 @@ class KokoroTTSEntity(TextToSpeechEntity):
         self._sample_rate = sample_rate
         self._language = language
 
-        # Required TTS entity attributes
-        self._attr_default_language = "en"
-        self._attr_supported_languages = ["en"]
+        # Required TTS entity attributes.
+        # Advertise every language Kokoro can speak: Home Assistant hides the
+        # entity from any pipeline whose language is not listed here.
+        self._attr_supported_languages = SUPPORTED_LANGUAGES
+        self._attr_default_language = LANGUAGE_HA_CODE_MAP.get(
+            language or "", DEFAULT_HA_LANGUAGE
+        )
         self._attr_supported_options = SUPPORTED_OPTIONS
 
     @staticmethod


### PR DESCRIPTION
## Problem

`KokoroTTSEntity` advertises a single hardcoded language:

```python
self._attr_supported_languages = ["en"]
```

Home Assistant hides a TTS entity from any pipeline whose language is not listed
in `supported_languages`. On a non-English Assist pipeline the Kokoro entity is
therefore greyed out in the "Text-to-speech" dropdown and cannot be selected at
all — even though Kokoro ships voices for nine languages, and this integration
already knows about every one of them (`PERSONA_MAPPINGS`, `LANGUAGE_CODE_MAP`).

The workaround users reach for is `["en,fr"]`, which is a single string
containing a comma rather than two language codes. It papers over the symptom
and still covers only two of the nine languages.

## Fix

Map the language display names the integration already uses to the language
codes Home Assistant expects, and derive the advertised list from that map:

```python
LANGUAGE_HA_CODE_MAP: dict[str, str] = {
    "American English": "en",
    "British English": "en-GB",
    "Japanese": "ja",
    "Mandarin Chinese": "zh",
    "Spanish": "es",
    "French": "fr",
    "Hindi": "hi",
    "Italian": "it",
    "Brazilian Portuguese": "pt-BR",
}

SUPPORTED_LANGUAGES: list[str] = sorted(set(LANGUAGE_HA_CODE_MAP.values()))
```

The list is derived from the voices Kokoro ships with rather than written by
hand, so adding a voice for a new language keeps the two in sync automatically.

`default_language` now follows the language configured on the config entry
(`French` -> `fr`), falling back to `en` when nothing is configured or when
"All Languages" is selected.

## Testing

Verified on Home Assistant with a French (`fr`) Assist pipeline: the Kokoro
entity is now selectable where it previously was not, and synthesis uses the
French voice as expected.

## Note

This is independent of my streaming PR. Both branch from the same commit and
touch `const.py` / `tts.py`, so whichever lands second will need a trivial
rebase — happy to do that whenever suits you.
