### PR TITLE
feat: stream TTS audio sentence by sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 
 - 🔊 Convert text to speech using Kokoro FastAPI  
 - ⚡ Low-latency responses for near real-time playback  
+- 🚀 Streaming synthesis — speech starts on the first sentence, while a conversation agent is still writing  
 - 🎙️ Voice selection with per-call overrides  
 - 🔧 Configurable server URL and parameters  
 - 🏠 Works with any Home Assistant `media_player` entity  
@@ -209,6 +210,22 @@ data:
 target:
   entity_id: tts.kokoro
 ```
+
+**Streaming (conversation agents)**
+
+When Kokoro is the TTS engine of an Assist pipeline, synthesis starts as soon as the
+conversation agent has finished its **first sentence**, rather than waiting for the
+whole reply. On a multi-sentence answer this hides most of the generation time.
+
+Streaming is automatic — there is nothing to configure. Two things worth knowing:
+
+- Each sentence is synthesised as its own request and the audio is concatenated, so
+  the format must be concatenable. `mp3`, `opus` and `pcm` are; `wav` and `flac`
+  carry a per-file header and are not. If the configured format is not stream-safe,
+  `mp3` is used **for streaming only** — regular `tts.speak` calls keep the format
+  you configured.
+- Non-streaming callers (like the `tts.speak` example above) are unaffected and
+  continue to use the single-request path.
 
 ---
 

--- a/custom_components/kokoro_tts/const.py
+++ b/custom_components/kokoro_tts/const.py
@@ -27,6 +27,12 @@ DEFAULT_FORMAT = "mp3"
 DEFAULT_SAMPLE_RATE = 24000
 DEFAULT_VOLUME_MULTIPLIER = 1.0
 
+# Streaming synthesises one sentence per request and concatenates the audio,
+# so the format must survive concatenation. Container formats that carry a
+# per-file header (wav, flac) do not.
+STREAM_SAFE_FORMATS: tuple[str, ...] = ("mp3", "opus", "pcm")
+DEFAULT_STREAM_FORMAT = "mp3"
+
 # Voice mapping: technical_name -> (language, gender, display_name)
 PERSONA_MAPPINGS = {
     # American English (🇺🇸)

--- a/custom_components/kokoro_tts/tts.py
+++ b/custom_components/kokoro_tts/tts.py
@@ -1,13 +1,20 @@
 """Kokoro TTS entity for Home Assistant."""
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import aiohttp
 import base64
 import logging
+import re
 
-from homeassistant.components.tts.entity import TextToSpeechEntity, TtsAudioType
+from homeassistant.components.tts.entity import (
+    TextToSpeechEntity,
+    TTSAudioRequest,
+    TTSAudioResponse,
+    TtsAudioType,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -25,9 +32,11 @@ from .const import (
     DEFAULT_MODEL,
     DEFAULT_SAMPLE_RATE,
     DEFAULT_SPEED,
+    DEFAULT_STREAM_FORMAT,
     DEFAULT_VOLUME_MULTIPLIER,
     DOMAIN,
     LANGUAGE_CODE_MAP,
+    STREAM_SAFE_FORMATS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,6 +46,30 @@ SUPPORTED_OPTIONS = ["persona", "speed", "format", "sample_rate", "volume_multip
 
 # Default entity name
 DEFAULT_NAME = "kokoro"
+
+# Size of the audio chunks yielded while streaming a sentence.
+STREAM_CHUNK_BYTES = 4096
+
+# A sentence ends on terminal punctuation followed by whitespace. Requiring the
+# trailing whitespace keeps decimals ("12.5") and mid-generation abbreviations
+# from being treated as sentence boundaries.
+SENTENCE_END_PATTERN = re.compile(r"[.!?…]+[\"'”’)\]]*\s+")
+
+
+def split_sentences(buffer: str) -> tuple[list[str], str]:
+    """Split a text buffer into complete sentences plus a trailing remainder.
+
+    The remainder is text that has not yet been terminated by punctuation; it is
+    kept in the buffer until more text arrives, or flushed when the stream ends.
+    """
+    sentences: list[str] = []
+    last_end = 0
+    for match in SENTENCE_END_PATTERN.finditer(buffer):
+        sentence = buffer[last_end : match.end()].strip()
+        if sentence:
+            sentences.append(sentence)
+        last_end = match.end()
+    return sentences, buffer[last_end:]
 
 
 async def async_setup_entry(
@@ -136,29 +169,31 @@ class KokoroTTSEntity(TextToSpeechEntity):
             return persona[0].lower()
         return None
 
-    async def async_get_tts_audio(
-        self, message: str, language: str, options: dict[str, Any] | None = None
-    ) -> TtsAudioType:
-        """Get TTS audio from Kokoro API."""
-        if not message.strip():
-            raise ValueError("Message cannot be empty")
-
-        # Merge entity defaults with per-call options
+    def _resolve_options(self, options: dict[str, Any] | None) -> dict[str, Any]:
+        """Merge entity defaults with per-call options."""
         opts = options or {}
-        persona = opts.get("persona", opts.get("voice", self._persona))
-        speed = float(opts.get("speed", self._speed))
-        fmt = (opts.get("format", self._fmt) or self._fmt).lower()
-        volume_multiplier = float(opts.get("volume_multiplier", DEFAULT_VOLUME_MULTIPLIER))
+        return {
+            "persona": opts.get("persona", opts.get("voice", self._persona)),
+            "speed": float(opts.get("speed", self._speed)),
+            "fmt": (opts.get("format", self._fmt) or self._fmt).lower(),
+            "volume_multiplier": float(
+                opts.get("volume_multiplier", DEFAULT_VOLUME_MULTIPLIER)
+            ),
+        }
 
-        # Build API payload
+    def _build_payload(
+        self, message: str, resolved: dict[str, Any], *, stream: bool
+    ) -> dict[str, Any]:
+        """Build the /v1/audio/speech request payload."""
+        persona = resolved["persona"]
         payload: dict[str, Any] = {
             "model": self._model,
             "input": message,
             "voice": persona or "af_heart",
-            "response_format": fmt,
-            "download_format": fmt,
-            "speed": speed,
-            "stream": False,
+            "response_format": resolved["fmt"],
+            "download_format": resolved["fmt"],
+            "speed": resolved["speed"],
+            "stream": stream,
         }
 
         # Add lang_code if we can determine one
@@ -166,18 +201,39 @@ class KokoroTTSEntity(TextToSpeechEntity):
         if lang_code:
             payload["lang_code"] = lang_code
 
-        if volume_multiplier != 1.0:
-            payload["volume_multiplier"] = volume_multiplier
+        if resolved["volume_multiplier"] != 1.0:
+            payload["volume_multiplier"] = resolved["volume_multiplier"]
 
+        return payload
+
+    def _build_headers(self) -> dict[str, str]:
+        """Build the request headers, including auth when configured."""
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if self._api_key and self._api_key not in ("x", "not-needed", ""):
             headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
 
-        url = f"{self._base_url}/v1/audio/speech"
+    @property
+    def _speech_url(self) -> str:
+        """Return the speech endpoint URL."""
+        return f"{self._base_url}/v1/audio/speech"
+
+    async def async_get_tts_audio(
+        self, message: str, language: str, options: dict[str, Any] | None = None
+    ) -> TtsAudioType:
+        """Get TTS audio from Kokoro API."""
+        if not message.strip():
+            raise ValueError("Message cannot be empty")
+
+        resolved = self._resolve_options(options)
+        fmt = resolved["fmt"]
+        payload = self._build_payload(message, resolved, stream=False)
         timeout = aiohttp.ClientTimeout(total=60, connect=10)
 
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.post(url, json=payload, headers=headers) as response:
+            async with session.post(
+                self._speech_url, json=payload, headers=self._build_headers()
+            ) as response:
                 if response.status != 200:
                     error_text = await response.text()
                     _LOGGER.warning(
@@ -219,3 +275,94 @@ class KokoroTTSEntity(TextToSpeechEntity):
 
                 _LOGGER.debug("TTS audio generated: %d bytes, format: %s", len(audio_bytes), fmt)
                 return fmt, audio_bytes
+
+    def async_supports_streaming_input(self) -> bool:
+        """Return True - text can be consumed as it is generated.
+
+        This lets the Assist pipeline forward the conversation agent's output as
+        it arrives instead of buffering the whole reply, so synthesis can start
+        on the first finished sentence.
+        """
+        return True
+
+    async def async_stream_tts_audio(
+        self, request: TTSAudioRequest
+    ) -> TTSAudioResponse:
+        """Stream audio, synthesising each sentence as soon as it is complete."""
+        resolved = self._resolve_options(request.options)
+        fmt = resolved["fmt"]
+
+        # Streaming issues one request per sentence and concatenates the audio.
+        # Container formats carrying a per-file header (wav, flac) cannot be
+        # concatenated that way, so fall back to a stream-safe format.
+        if fmt not in STREAM_SAFE_FORMATS:
+            _LOGGER.debug(
+                "Format %s cannot be concatenated while streaming, using %s instead",
+                fmt,
+                DEFAULT_STREAM_FORMAT,
+            )
+            fmt = DEFAULT_STREAM_FORMAT
+            resolved = {**resolved, "fmt": fmt}
+
+        return TTSAudioResponse(
+            extension=fmt,
+            data_gen=self._async_stream_audio(request.message_gen, resolved),
+        )
+
+    async def _async_stream_audio(
+        self, message_gen: AsyncGenerator[str], resolved: dict[str, Any]
+    ) -> AsyncGenerator[bytes]:
+        """Consume the text stream and yield audio for each complete sentence."""
+        # No total timeout: the generator lives as long as the agent is talking.
+        timeout = aiohttp.ClientTimeout(total=None, connect=10, sock_read=60)
+        sentence_count = 0
+
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            buffer = ""
+            async for chunk in message_gen:
+                buffer += chunk
+                sentences, buffer = split_sentences(buffer)
+                for sentence in sentences:
+                    sentence_count += 1
+                    async for audio in self._async_stream_sentence(
+                        session, sentence, resolved
+                    ):
+                        yield audio
+
+            # Flush the tail: the last sentence often has no trailing whitespace.
+            tail = buffer.strip()
+            if tail:
+                sentence_count += 1
+                async for audio in self._async_stream_sentence(session, tail, resolved):
+                    yield audio
+
+        _LOGGER.debug(
+            "TTS stream complete: %d sentence(s), format: %s",
+            sentence_count,
+            resolved["fmt"],
+        )
+
+    async def _async_stream_sentence(
+        self,
+        session: aiohttp.ClientSession,
+        message: str,
+        resolved: dict[str, Any],
+    ) -> AsyncGenerator[bytes]:
+        """Synthesise one sentence and yield its audio as it arrives."""
+        payload = self._build_payload(message, resolved, stream=True)
+
+        async with session.post(
+            self._speech_url, json=payload, headers=self._build_headers()
+        ) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                _LOGGER.warning(
+                    "Kokoro TTS API error %d: %s", response.status, error_text[:200]
+                )
+                raise RuntimeError(
+                    self._handle_http_error(response.status, error_text)
+                )
+
+            async for chunk in response.content.iter_chunked(STREAM_CHUNK_BYTES):
+                if chunk:
+                    yield chunk


### PR DESCRIPTION
## What

Implements Home Assistant's streaming TTS API (`async_supports_streaming_input`
/ `async_stream_tts_audio`), so a conversation agent's reply is synthesised
sentence by sentence as it is generated, instead of only once the full reply is
known.

## Why

Today the pipeline waits for the agent to finish generating, then sends the
whole reply to Kokoro, then plays the result. Both waits are serial, so the user
hears nothing until every step is done. The longer the reply, the worse it gets.

Measured on a Home Assistant Voice PE, same long reply, same voice:

| | Time to first audio |
|---|---|
| before | ~5 s |
| after | immediate |

The gain grows with reply length. With a local LLM there is a second gain on top
of this: the first sentence is synthesised while the model is still generating
the next one, so that part of the wait disappears entirely.

## How

- incoming text is buffered and split on terminal punctuation followed by
  whitespace
- each complete sentence is sent to `/v1/audio/speech` with `stream: true`
- audio is yielded in 4 KiB chunks as it arrives
- the trailing buffer is flushed at the end, since the final sentence usually
  has no trailing whitespace
- a single `aiohttp` session is reused for the whole reply
- the streaming path uses no total timeout (`total=None`, with `connect` and
  `sock_read` still bounded): the generator lives for as long as the agent is
  talking

Shared helpers (`_resolve_options`, `_build_payload`, `_build_headers`,
`_speech_url`) were factored out so both paths build requests identically.
`async_get_tts_audio` is otherwise untouched, so nothing changes for callers
that do not stream.

## Format handling

Streaming issues one request per sentence and concatenates the results, so the
response format has to survive concatenation. Container formats that carry a
per-file header (`wav`, `flac`) do not — four concatenated WAV files are not a
valid WAV file. When streaming, a configured non-concatenable format therefore
falls back to `mp3`:

```python
STREAM_SAFE_FORMATS: tuple[str, ...] = ("mp3", "opus", "pcm")
DEFAULT_STREAM_FORMAT = "mp3"
```

This is not a quality compromise. Home Assistant converts the stream to whatever
format the satellite asks for via ffmpeg, and that conversion is itself
streaming (`FFMPEG_CHUNK_SIZE`), so it does not reintroduce buffering. Producing
the satellite's preferred format directly would break concatenation with no
ffmpeg pass available to repair it.

## Known limitation

Abbreviations are treated as sentence ends: `M. Dupont arrives.` splits into
`M.` and `Dupont arrives.`. The audio is still correct, but there is a slightly
unnatural pause. Decimals (`12.5`) and ellipses (`Yes...`) are handled properly
— the split requires trailing whitespace, which is what protects them.

I left it there rather than ship an abbreviation list that would need to be
maintained per language, but I'm happy to add a guard if you'd prefer not to
ship that behaviour.

## Note

This is independent of my `supported_languages` PR. Both branch from the same
commit and touch `const.py` / `tts.py`, so whichever lands second will need a
trivial rebase — happy to do that whenever suits you.
