### PR TITLE
fix: reload the config entry when options change

### DIFF
--- a/custom_components/kokoro_tts/__init__.py
+++ b/custom_components/kokoro_tts/__init__.py
@@ -31,12 +31,3 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload config entry when options change.
-
-    This ensures the TTS entity is recreated with updated settings
-    (persona, speed, format, etc.) without requiring a HA restart.
-    """
-    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/kokoro_tts/config_flow.py
+++ b/custom_components/kokoro_tts/config_flow.py
@@ -514,8 +514,13 @@ class KokoroConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 # Options Flow
 # ---------------------------------------------------------------------------
 
-class KokoroOptionsFlow(config_entries.OptionsFlow):
-    """Handle options flow for Kokoro TTS."""
+class KokoroOptionsFlow(config_entries.OptionsFlowWithReload):
+    """Handle options flow for Kokoro TTS.
+
+    Subclassing OptionsFlowWithReload makes Home Assistant reload the config
+    entry whenever the options change, so the TTS entity is recreated with the
+    new persona, speed, format and sample rate without a restart.
+    """
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""


### PR DESCRIPTION
## Problem

Changing an option (persona, speed, format, sample rate) has no effect until
Home Assistant is restarted.

The options flow does store the new values — `async_create_entry` writes them to
the config entry. But the TTS entity reads its settings once, in
`async_setup_entry`, and holds them in `self._persona`, `self._speed`,
`self._fmt`, ... Without a reload, the live entity keeps the old values.

### To reproduce

1. Settings -> Devices & services -> Kokoro TTS -> **Configure**
2. Change the **voice** (persona) -> Submit
3. Do **not** restart Home Assistant
4. Call `tts.speak`

Expected: the new voice. Actual: the old voice, until a restart.

### The interesting part

`__init__.py` already contains a function written for exactly this:

```python
async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
    """Reload config entry when options change.

    This ensures the TTS entity is recreated with updated settings
    (persona, speed, format, etc.) without requiring a HA restart.
    """
    await hass.config_entries.async_reload(entry.entry_id)
```

The docstring describes the intended behaviour exactly — but the function is
never registered as an update listener, so it is never called. Grepping the
integration for `add_update_listener|async_on_unload|update_listener|
async_reload_entry` returns exactly one hit: the definition itself.

## Fix

Rather than wiring up the listener, this uses the approach the developer docs
now recommend:

> `OptionsFlowWithReload` will automatically reload the integration once the
> options change.
>
> Since the most common reason to add an update listener is to reload the
> integration when the options have changed, `OptionsFlowWithReload` avoids the
> need for that listener.

```diff
-class KokoroOptionsFlow(config_entries.OptionsFlow):
+class KokoroOptionsFlow(config_entries.OptionsFlowWithReload):
```

The now-redundant `async_reload_entry` is removed, so the change deletes more
code than it adds.

## Compatibility

`OptionsFlowWithReload` requires a reasonably recent Home Assistant. `hacs.json`
does not declare a minimum version, so I assumed current HA is fine.

If you would rather keep compatibility with older versions, the equivalent is to
keep `async_reload_entry` and register it instead:

```python
entry.async_on_unload(entry.add_update_listener(async_reload_entry))
```

Happy to switch to that — just say the word.

## Testing

The bug itself is confirmed by inspection: the reproduction above is reliable,
and the missing listener registration is unambiguous.

I am running this branch on my own instance now and will report back here to
confirm the fix behaves as expected; I did not want to claim a result I had not
observed yet.

Note that `KokoroOptionsFlow.__init__` still stores the entry as `self._entry`
rather than assigning `self.config_entry`; that is deliberate, since
`OptionsFlow.config_entry` is a property without a setter on recent cores.
